### PR TITLE
Prerequisite to allow lstore-release to build for distros with deb packaging

### DIFF
--- a/CPackConfig.cmake
+++ b/CPackConfig.cmake
@@ -2,20 +2,22 @@
 # http://www.cmake.org/Wiki/CMake:CPackConfiguration
 
 ### overrides
-set(CPACK_PACKAGE_NAME "apr-accre")
 set(APPLICATION_NAME "apr-accre")
 set(APPLICATION_VERSION_MAJOR 1)
 set(APPLICATION_VERSION_MINOR 5)
 set(APPLICATION_VERSION_PATCH 4)
 set(APPLICATION_VERSION "${APPLICATION_VERSION_MAJOR}.${APPLICATION_VERSION_MINOR}.${APPLICATION_VERSION_PATCH}")
-#set(CPACK_INSTALLED_DIRECTORIES "cmake/;/usr/local")
 set(CPACK_INSTALL_COMMANDS "${CMAKE_CURRENT_LIST_DIR}/configure --prefix=/usr --includedir=/usr/include/apr-ACCRE-1 --with-installbuilddir=/usr/lib/apr-ACCRE-1/build --with-devrandom=/dev/urandom " "make install")
 
 ### general settings
+set(CPACK_PACKAGE_NAME ${APPLICATION_NAME})
+set(CPACK_DEBIAN_PACKAGE_NAME "libapr-accre1")
+# ^^^ use this package name for debs b/c it is what makes dpkg-shlibdeps happy
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "ACCRE-modified libapr")
 set(CPACK_PACKAGE_DESCRIPTION "APR+some additional ACCRE patches")
 #set(CPACK_PACKAGE_DESCRIPTION_FILE "${CMAKE_CURRENT_SOURCE_DIR}/README")
-set(CPACK_PACKAGE_VENDOR "The SSH Library Development Team")
+set(CPACK_PACKAGE_CONTACT "Andrew Melo or Alan Tackett")
+set(CPACK_PACKAGE_VENDOR "Advanced Computing Center for Research and Education, Vanderbilt University")
 set(CPACK_PACKAGE_INSTALL_DIRECTORY ${CPACK_PACKAGE_NAME})
 #set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/COPYING")
 
@@ -39,22 +41,22 @@ if (WIN32)
     find_package(NSIS)
     if (NSIS_MAKE)
         set(CPACK_GENERATOR "${CPACK_GENERATOR};NSIS")
-        set(CPACK_NSIS_DISPLAY_NAME "The SSH Library")
+        set(CPACK_NSIS_DISPLAY_NAME ${APPLICATION_NAME})
         set(CPACK_NSIS_COMPRESSOR "/SOLID zlib")
-        set(CPACK_NSIS_MENU_LINKS "http://www.libssh.org/" "libssh homepage")
+        set(CPACK_NSIS_MENU_LINKS "http://apr.apache.org/" "libapr homepage")
     endif (NSIS_MAKE)
 endif (WIN32)
 
-set(CPACK_PACKAGE_INSTALL_DIRECTORY "libssh")
+set(CPACK_PACKAGE_INSTALL_DIRECTORY "libapr")
 
 set(CPACK_PACKAGE_FILE_NAME ${APPLICATION_NAME}-${CPACK_PACKAGE_VERSION})
 
 set(CPACK_COMPONENT_LIBRARIES_DISPLAY_NAME "Libraries")
 set(CPACK_COMPONENT_HEADERS_DISPLAY_NAME "C/C++ Headers")
 set(CPACK_COMPONENT_LIBRARIES_DESCRIPTION
-  "Libraries used to build programs which use libssh")
+  "Libraries used to build programs which use libapr")
 set(CPACK_COMPONENT_HEADERS_DESCRIPTION
-  "C/C++ header files for use with libssh")
+  "C/C++ header files for use with libapr")
 set(CPACK_COMPONENT_HEADERS_DEPENDS libraries)
 #set(CPACK_COMPONENT_APPLICATIONS_GROUP "Runtime")
 set(CPACK_COMPONENT_LIBRARIES_GROUP "Development")


### PR DESCRIPTION
Add debian package name and package contact/maintainer plus CPack cleanup
